### PR TITLE
Improve block list, error handling. Add IP address anonymizer

### DIFF
--- a/blockList.json
+++ b/blockList.json
@@ -1,2 +1,9 @@
-[
-]
+{
+	"addresses" : {
+		"martians":  [ "becc30d85274d04c45b8a5dde99e31cf" ]
+	},
+	"words" : {
+		"swear words" : [ "thunderation", "gadzooks" ]
+	}
+
+}

--- a/server.js
+++ b/server.js
@@ -6,11 +6,71 @@
 //  Distributed under the ISC license.
 //  See the accompanying file LICENSE or https://opensource.org/licenses/ISC
 
+
 var http = require("http"),
-  url = require("url"),
-  path = require("path"),
-  fs = require("fs")
+    url = require("url"),
+    path = require("path"),
+    fs = require("fs"),
+    crypto = require("crypto");
+
+const DEFAULT_DIFFICULTY_MS = 100;
+
 port = process.argv[2] || 8081;
+
+let serverParams = JSON.parse(fs.readFileSync('./serverParams.json', 'utf-8'));
+
+// We use a salt and a number of iterations to hash IP addresses.
+// If either of those aren't defined, then they're generated here. The salt
+// is randomly generated, and the number of iterations is obtained by benchmarking
+// how many iterations we can do.
+//
+// Intentionally, neither result is given to the user. This ensures the hashes will
+// be only valid for one run and IP addresses cannot be recovered from the hash.
+
+if (!serverParams["salt"]) {
+  serverParams["salt"] = crypto.randomBytes(32).toString('hex');
+  console.log("Generated random salt");
+}
+
+if (!serverParams["difficulty"]) {
+  var start = Date.now();
+  var iterations = 0;
+  while( Date.now() - start < DEFAULT_DIFFICULTY_MS ) {
+    var hash = crypto.createHash("sha256");
+    hash.update("Hello");
+    hash.digest();
+    iterations++;
+  }
+
+  serverParams["difficulty"] = iterations;
+  console.log("Using benchmarked number of iterations");
+}
+
+var hashCache = {}
+
+var hashAddress = function(address) {
+  if (hashCache[address] !== undefined) {
+    return hashCache[address];
+  }
+
+  var hash = crypto.createHash("sha256");
+  hash.update(serverParams["salt"]);
+  hash.update(address);
+  var result = hash.digest();
+
+  for(var i=0;i<serverParams["difficulty"];i++) {
+    var hash = crypto.createHash("sha256");
+    hash.update(result);
+    result = hash.digest();
+  }
+
+  // We want text at the end, shorted for comfort
+  result = crypto.createHash("sha256").update(result).digest("hex").substring(0, 32);
+  hashCache[address] = result;
+
+  return result;
+}
+
 
 http.createServer(function (request, response) {
 
@@ -32,7 +92,6 @@ http.createServer(function (request, response) {
       prepareInformation();
       return;
     case "/ip.json":
-      // pageData = "{" + JSON.stringify("ip") + ": " + JSON.stringify(request.connection.remoteAddress.split(':')[3]) + "}";
       pageData = "{" + JSON.stringify("ip") + ": " + JSON.stringify(request.headers['x-forwarded-for']) + "}";
       sendPage();
       return;
@@ -101,22 +160,82 @@ setInterval(() => {
 const WebSocket = require('ws');
 
 const wss = new WebSocket.Server({ port: 8080 });
+var seenRequests = {};
+var blockList = {
+	addresses : { },
+	words : { }
+};
 
-wss.on('connection', function connection(ws) {
+
+wss.on('connection', function connection(ws,req) {
   ws.on('message', function incoming(data) {
-    var onBlockList = false;
-    var messageData = JSON.parse(data);
-    messageData.age = Date.now();
-    var exist = false;
-    let blockList = JSON.parse(fs.readFileSync('./blockList.json', 'utf-8'));
-    for (let i = 0; i < blockList.length; i++) {
-      if (blockList[i] == messageData.Visit.split('/')[2].split(':')[0]) {
-        onBlockList = true;
-      }
+
+    let ipAddress = hashAddress(req.headers['x-forwarded-for'] || req.connection.remoteAddress);
+    let key = require("crypto").createHash("sha256").update(ipAddress + ":" + data).digest();
+
+    if ( seenRequests[key] == undefined) {
+      console.log("MSG FROM " + ipAddress + ": " + data);
+      seenRequests[key]=1;
     }
+
+    let messageData;
+		try {
+			messageData = JSON.parse(data);
+		} catch( error ) {
+			console.log("Error: " + error);
+			console.log("Bad JSON received from " + ipAddress + ": " + data);
+			ws.send(JSON.stringify({ error:  'Your JSON is bad, and you should feel bad.' }));
+			return;
+		}
+
+		let newBlockList;
+    try {
+			newBlockList = JSON.parse(fs.readFileSync('./blockList.json', 'utf-8'));
+			blockList = newBlockList;
+		} catch ( error ) {
+			console.log("Error: " + error);
+			console.log("Failed to parse blockList.json, block list not updated.");
+		}
+
+
+    let visitAddress = messageData.Visit.split('/')[2].split(':')[0];
+    let onBlockList = false;
+
+    for (var banReason in blockList["addresses"]) {
+      blockList["addresses"][banReason].forEach(function(banned) {
+        if (banned == visitAddress || banned == ipAddress) {
+          console.log("BAN: Matched " + banReason + ", address " + banned);
+          onBlockList = true;
+          return;
+        }
+      });
+    }
+
+    for(var banReason in blockList["words"]) {
+      blockList["words"][banReason].forEach(function(banned) {
+        var bannedLower = banned.toLowerCase();
+
+        for (var key in messageData) {
+          if ( typeof messageData[key] != "string" ) {
+            continue;
+          }
+          if ( messageData[key].toLowerCase().includes(bannedLower)) {
+            console.log("BAN: words matched " + banReason + ", field '" + key + "' value '" + messageData[key] + "' contains '" + banned + "'");
+            onBlockList = true;
+            return;
+          }
+        }
+      });
+    }
+
     if (onBlockList) {
+      console.log("Blocked request from " + ipAddress);
+      console.log("");
       return;
     }
+
+    var exist = false;
+    messageData.age = Date.now();
     for (let i = 0; i < locationList.length; i++) {
       if (locationList[i].id == messageData.id) {
         locationList[i] = messageData;
@@ -130,3 +249,6 @@ wss.on('connection', function connection(ws) {
 });
 
 console.log("Decentralized GoTo server running at\n=> http://localhost:" + port + "/\nCTRL + C to shutdown");
+
+
+/* vim: set tabstop=2:softtabstop=2:shiftwidth=2:expandtab */

--- a/serverParams.json
+++ b/serverParams.json
@@ -1,0 +1,5 @@
+{
+	"salt": "",
+	"difficulty": 0
+}
+

--- a/test_bad.json
+++ b/test_bad.json
@@ -1,0 +1,1 @@
+{"Domain Name":"Gadzooks! Horrible Domain","Owner":"Test User","Visit":"hifi://127.123.123.123:40102/154.572,-97.626,-417.945/0,1,0,-1.52586e-05","id":"{f63365d4-7097-4cda-aa3d-7e575c6a60f4}","People":1}

--- a/test_fetch.sh
+++ b/test_fetch.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+curl -H "X-Forwarded-For: 127.0.0.1" http://localhost:8081/goto.json
+

--- a/test_good.json
+++ b/test_good.json
@@ -1,0 +1,1 @@
+{"Domain Name":"Test Domain","Owner":"Test User","Visit":"hifi://127.123.123.123:40102/154.572,-97.626,-417.945/0,1,0,-1.52586e-05","id":"{f63365d4-7097-4cda-aa3d-7e575c6a60f4}","People":1}

--- a/test_ip.sh
+++ b/test_ip.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+curl -H "X-Forwarded-For: 127.0.0.1" http://localhost:8081/ip.json
+

--- a/test_submit.js
+++ b/test_submit.js
@@ -1,0 +1,22 @@
+// GoTo tester
+//
+// Created by Dale Glass in 2021
+//
+
+const WebSocket = require('ws');
+const ws = new WebSocket('ws://localhost:8080/');
+const fs = require("fs");
+
+
+ws.on('open', function open() {
+  ws.send('This is not JSON');
+	ws.send(fs.readFileSync('./test_good.json', 'utf-8'));
+	ws.send(fs.readFileSync('./test_bad.json', 'utf-8'));
+  process.exit(0);
+});
+
+ws.on('message', function incoming(data) {
+  console.log("REPLY: '" + data + "'");
+});
+
+/* vim: set tabstop=2:softtabstop=2:shiftwidth=2:expandtab */


### PR DESCRIPTION
* Better block list - filter IP addresses AND text
* Better error tolerance - don't fail on bad JSON
* IP address anonymizer
* Test scripts with test data
* Console output about submissions and ban activity

The IP address anonymizer works by hashing IP addresses together with a salt string, and iterating a given amount of times.

By default, the salt is random and not given to the user, and the number of iterations is calculated by hashing until 100ms pass. This means that the hashes are different on every run, and the IP address ban list is only valid so long the server keeps running.